### PR TITLE
fix: 유저 로그인시 휴대폰 번호 null 입력 오류 수정

### DIFF
--- a/mlb/src/main/java/com/project/mlb/member/domain/LoginId.java
+++ b/mlb/src/main/java/com/project/mlb/member/domain/LoginId.java
@@ -5,7 +5,9 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class LoginId {
 

--- a/mlb/src/main/java/com/project/mlb/member/domain/Member.java
+++ b/mlb/src/main/java/com/project/mlb/member/domain/Member.java
@@ -48,4 +48,32 @@ public class Member {
         this.phone = phone;
     }
 
+    public Long getId() {
+        return id;
+    }
+
+    public LoginId getLoginId() {
+        return loginId;
+    }
+
+    public Username getUsername() {
+        return username;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public Password getPassword() {
+        return password;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
 }

--- a/mlb/src/main/java/com/project/mlb/member/domain/Password.java
+++ b/mlb/src/main/java/com/project/mlb/member/domain/Password.java
@@ -6,7 +6,9 @@ import java.util.Objects;
 import java.util.regex.Pattern;
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.Getter;
 
+@Getter
 @Embeddable
 public class Password {
 

--- a/mlb/src/main/java/com/project/mlb/member/service/MemberService.java
+++ b/mlb/src/main/java/com/project/mlb/member/service/MemberService.java
@@ -37,6 +37,7 @@ public class MemberService {
                 .nickname(signUpRequest.getNickname())
                 .password(Password.of(encryptor, signUpRequest.getPassword()))
                 .email(signUpRequest.getEmail())
+                .phone(signUpRequest.getPhone())
                 .build();
         memberRepository.save(member);
     }

--- a/mlb/src/test/java/com/project/mlb/member/service/MemberServiceTest.java
+++ b/mlb/src/test/java/com/project/mlb/member/service/MemberServiceTest.java
@@ -3,12 +3,14 @@ package com.project.mlb.member.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.project.mlb.member.domain.Member;
 import com.project.mlb.member.domain.encryptor.Encryptor;
 import com.project.mlb.member.dto.SignUpRequest;
 import com.project.mlb.member.exception.DuplicateLoginIdException;
 import com.project.mlb.member.exception.DuplicateNicknameException;
 import com.project.mlb.member.exception.InvalidPasswordConfirmationException;
 import com.project.mlb.member.repository.MemberRepository;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -48,9 +50,15 @@ class MemberServiceTest {
     @Test
     void signUp() {
         memberService.signUp(signUpRequest);
-
-        assertThat(
-                memberRepository.findByLoginIdValueAndPasswordValue("test123", encryptor.encrypt("!Abc123123"))).isPresent();
+        Member findMember = memberRepository.findByLoginIdValueAndPasswordValue("test123", encryptor.encrypt("!Abc123123")).get();
+        Assertions.assertAll(
+                () -> assertThat(findMember.getLoginId().getValue()).isEqualTo("test123"),
+                () -> assertThat(findMember.getUsername().getValue()).isEqualTo(encryptor.encrypt("이호석")),
+                () -> assertThat(findMember.getNickname()).isEqualTo("키다리"),
+                () -> assertThat(findMember.getPassword().getValue()).isEqualTo(encryptor.encrypt("!Abc123123")),
+                () -> assertThat(findMember.getEmail()).isEqualTo("asdf@test.com"),
+                () -> assertThat(findMember.getPhone()).isEqualTo("010-0000-0000")
+        );
     }
 
     @DisplayName("회원가입시 비밀번호와 비밀번호 확인이 일치하지 않으면 회원가입을 실패한다.")


### PR DESCRIPTION
## ✅ 관련 이슈
#5 

<br>

## ✅ 문제 상황
postman으로 회원가입 테스트 후 MySQL workbench로 조회했을때 `phone` 컬럼이 null로 조회됨
![스크린샷 2023-04-30 오전 2 42 50](https://user-images.githubusercontent.com/66772624/235316574-8e04aa76-3e30-4849-a7d4-9974d5525031.png)

<br>

## 해결
dto -> entity로 변경 되는 service코드에서 phone 필드가 누락되어 있었음

<br>

## ✅ 배운점
단순한 필드 값의 누락이었지만, 
코드 라인 테스트 커버리지가 86이며 서비스 코드는 100% 커버하고 있었지만 테스트 코드를 통해 발견할 수 없었다.
**테스트 작성의 목적이 테스트 커버리지가 아닌 실제 삽입, 수정, 삭제와 같은 동작에서 정말 올바르게 수행됐는지 자세하게 확인해야함을 배웠다.**

<br>

### 문제의 기존 회원가입 테스트
```java
    @DisplayName("회원가입 조건을 만족하면 회원가입을 성공한다.")
    @Test
    void signUp() {
        memberService.signUp(signUpRequest);

        assertThat(
                memberRepository.findByLoginIdAndPasswordValue("test123", encryptor.encrypt("!Abc123123"))).isPresent();
    }
```
단순히 아이디, 비밀번호 필드만 검증하여 객체가 실제 DB에 저장되었는지만 확인한다.

<br>

### 개선한 회원가입 테스트
```java
    @DisplayName("회원가입 조건을 만족하면 회원가입을 성공한다.")
    @Test
    void signUp() {
        memberService.signUp(signUpRequest);
        Member findMember = memberRepository.findByLoginIdValueAndPasswordValue("test123", encryptor.encrypt("!Abc123123")).get();
        Assertions.assertAll(
                () -> assertThat(findMember.getLoginId().getValue()).isEqualTo("test123"),
                () -> assertThat(findMember.getUsername().getValue()).isEqualTo(encryptor.encrypt("이호석")),
                () -> assertThat(findMember.getNickname()).isEqualTo("키다리"),
                () -> assertThat(findMember.getPassword().getValue()).isEqualTo(encryptor.encrypt("!Abc123123")),
                () -> assertThat(findMember.getEmail()).isEqualTo("asdf@test.com"),
                () -> assertThat(findMember.getPhone()).isEqualTo("010-0000-0000")
        );
    }
```
회원가입은 당연히 통과해야 하며 모든 필드에 대한 검증을 함으로써 정말 올바르게 유저 데이터가 생성됐고, 저장되었는지 확인한다.